### PR TITLE
Clear the meter registry after each test in MetricsTest

### DIFF
--- a/riptide-spring-boot-autoconfigure/src/test/java/org/zalando/riptide/autoconfigure/metrics/MetricsTest.java
+++ b/riptide-spring-boot-autoconfigure/src/test/java/org/zalando/riptide/autoconfigure/metrics/MetricsTest.java
@@ -4,6 +4,7 @@ import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -64,6 +65,11 @@ final class MetricsTest {
 
     @Autowired
     private SimpleMeterRegistry registry;
+
+    @AfterEach
+    void teardown() {
+        registry.clear();
+    }
 
     @Test
     void shouldRecordRequests() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add a `teardown()` method which clears the `SimpleMeterRegistry` after each test.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There are some issues in the `MetricsTest`, specifically:
* `org.zalando.riptide.spring.metrics.MetricsTest.shouldRecordCircuitBreakers` is non-idempotent and fails if run twice in the same JVM
* `org.zalando.riptide.spring.metrics.MetricsTest.shouldRecordRequests` is order-dependent and can pass only when it's run first in the test class

These issues exist because each test pollutes some states shared among tests. Specifically, each test updates the `SimpleMeterRegistry` object, but the `SimpleMeterRegistry` is not reset when the test exits. It may be good to clean this state pollution so that some other tests do not fail in the future due to the shared state polluted by this test.

### Details
When running `MetricsTest.shouldRecordCircuitBreakers` twice, the test fails with the following error message:
```
Expected :4
Actual : 8
at org.zalando.riptide.autoconfigure.metrics.MetricsTest.shouldRecordCircuitBreakers(MetricsTest.java:202) 
assertEquals(4, timer.count());
```

When running `MetricsTest.shouldRecordRequests` after any other tests in the test class, the test fails with an assertion error:
```
org.opentest4j.AssertionFailedError:
Expected :2
Actual   : X
at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:510)
at org.zalando.riptide.autoconfigure.metrics.MetricsTest.shouldRecordRequests(MetricsTest.java:89)
```
The root cause is that the new timers get added in each test to the `SimpleMeterRegistry`, but it's not cleared when the test finishes. This polluted state can cause subsequent tests to fail.

With the proposed fix, each test in `MetricsTest` does not pollute the shared state(and the issues outlined above are resolved).
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
